### PR TITLE
Fixed typo when printing out kernel version.

### DIFF
--- a/modules/Misc_module
+++ b/modules/Misc_module
@@ -264,7 +264,7 @@ msgFunc green "System Information display Page 1"
 msgFunc line
 
 msgFunc norm "Uptime = $(uptime -p)"
-msgFunc norm "Kernal = $(uname -svr)"
+msgFunc norm "Kernel = $(uname -svr)"
 msgFunc norm "Operating System = = $(uname -mo)"
 msgFunc norm "Network node name = $(uname -n)"
 msgFunc norm "User name = $USER"


### PR DESCRIPTION
Small typo when script prints out kernel version in `11. system information` option. It used to print `Kernal` instead of `Kernel`.